### PR TITLE
[CI] allow for manual triggered jobs to accept inputs

### DIFF
--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -50,6 +50,7 @@ jobs:
       TERM: xterm
     name: Run cypress tests
     steps:
+      - name: Verify inputs
       - run: |
           echo "Repo: ${{ env.REPO }}"
           echo "Test branch: ${{ env.TEST_BRANCH }}"

--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -11,7 +11,7 @@ on:
       branch:
         description: 'Execute tests from this branch'
         required: true
-        default: $env:GITHUB_BASE_REF
+        default: ' ${{ env.GITHUB_BASE_REF }}'
         type: string
 
 

--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -23,6 +23,11 @@ on:
         default: ''
         required: false
         type: string
+      pr_number:
+        description: 'Pull request number to link results'
+        default: ''
+        required: false
+        type: number
 
 env:
   REPO: ${{ inputs.repository != '' && inputs.repository || 'opensearch-project/opensearch-dashboards-functional-test' }}
@@ -36,6 +41,9 @@ env:
   CYPRESS_VISBUILDER_ENABLED: true
   CYPRESS_DATASOURCE_MANAGEMENT_ENABLED: false
   OSD_SNAPSHOT_SKIP_VERIFY_CHECKSUM: true
+  COMMENT_TAG: '[MANUAL CYPRESS TEST RUN RESULTS]'
+  COMMENT_SUCCESS_MSG: ':white_check_mark: Cypress test run succeeded.'
+  COMMENT_FAILURE_MSG: ':x: Cypress test run failed.'
 
 jobs:
   cypress-tests:
@@ -127,3 +135,37 @@ jobs:
           name: ftr-cypress-results
           path: ${{ env.FTR_PATH }}/cypress/results
           retention-days: 1
+
+  add-comment:
+    needs: [cypress-tests]
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.pr_number != '' }}
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ inputs.pr_number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: "${{ env.COMMENT_TAG }}"
+
+      - name: Add comment on the PR
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ inputs.pr_number }}
+          body: |
+            ### ${{ env.COMMENT_TAG }}
+
+            #### ${{ needs.cypress-tests.result == 'success' && env.COMMENT_SUCCESS_MSG || env.COMMENT_FAILURE_MSG }}
+
+            #### Inputs:
+            Test repo: `${{ env.REPO }}`
+            Test branch: `${{ env.TEST_BRANCH }}`
+            Spec: `${{ env.SPEC }}${{ env.ADDITIONAL_SPEC }}`
+
+            Link to results: 
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          edit-mode: replace

--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -8,18 +8,30 @@ on:
       - '**/*.md'
   workflow_dispatch:
     inputs: 
-      branch:
-        description: 'Execute tests from this branch'
+      repository:
+        description: 'Repo of the tests'
+        default: 'opensearch-project/opensearch-dashboards-functional-test'
         required: true
-        default: ' ${{ env.GITHUB_BASE_REF }}'
+        type: string
+      branch:
+        description: 'Branch of the tests (default: target branch)'
+        default: ''
+        required: false
+        type: string
+      specs:
+        description: 'Additional tests to run'
+        default: ''
+        required: false
         type: string
 
-
 env:
+  REPO: ${{ inputs.repository != '' && inputs.repository || 'opensearch-project/opensearch-dashboards-functional-test' }}
+  TEST_BRANCH: ${{ inputs.branch != '' && inputs.branch || github.base_ref }}
   FTR_PATH: 'ftr'
   START_CMD: 'node ../scripts/opensearch_dashboards --dev --no-base-path --no-watch'
   OPENSEARCH_SNAPSHOT_CMD: 'node ../scripts/opensearch snapshot'
   SPEC: 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js,'
+  ADDITIONAL_SPEC: "${{ inputs.specs != '' && inputs.specs || '' }}"
   CYPRESS_BROWSER: 'chromium'
   CYPRESS_VISBUILDER_ENABLED: true
   CYPRESS_DATASOURCE_MANAGEMENT_ENABLED: false
@@ -38,7 +50,11 @@ jobs:
       TERM: xterm
     name: Run cypress tests
     steps:
-      - run: echo "Targetted branch is ${{ inputs.branch }}"
+      - run: |
+          echo "Repo: ${{ env.REPO }}"
+          echo "Test branch: ${{ env.TEST_BRANCH }}"
+          echo "Extra spec: ${{ env.ADDITIONAL_SPEC }}"
+
       - name: Checkout code
         uses: actions/checkout@v2
 
@@ -63,8 +79,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ${{ env.FTR_PATH }}
-          repository: opensearch-project/opensearch-dashboards-functional-test
-          ref: '${{ inputs.branch }}'
+          repository: ${{ env.REPO }}
+          ref: '${{ env.TEST_BRANCH }}'
 
       - name: Get Cypress version
         id: cypress_version
@@ -88,7 +104,7 @@ jobs:
           working-directory: ${{ env.FTR_PATH }}
           start: ${{ env.OPENSEARCH_SNAPSHOT_CMD }}, ${{ env.START_CMD }}
           wait-on: 'http://localhost:9200, http://localhost:5601'
-          command: yarn cypress:run-without-security --browser ${{ env.CYPRESS_BROWSER }} --spec ${{ env.SPEC }}
+          command: yarn cypress:run-without-security --browser ${{ env.CYPRESS_BROWSER }} --spec ${{ env.SPEC }}${{ env.ADDITIONAL_SPEC }}
 
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -11,7 +11,7 @@ on:
       branch:
         description: 'Execute tests from this branch'
         required: true
-        default: '${{ github.base_ref }}'
+        default: '${{ GITHUB_BASE_REF }}'
         type: string
 
 
@@ -63,7 +63,7 @@ jobs:
         with:
           path: ${{ env.FTR_PATH }}
           repository: opensearch-project/opensearch-dashboards-functional-test
-          ref: '${{ github.base_ref }}'
+          ref: '${{ inputs.branch }}'
 
       - name: Get Cypress version
         id: cypress_version

--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -11,7 +11,7 @@ on:
       branch:
         description: 'Execute tests from this branch'
         required: true
-        default: '${{ GITHUB_BASE_REF }}'
+        default: $env:GITHUB_BASE_REF
         type: string
 
 

--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -38,6 +38,7 @@ jobs:
       TERM: xterm
     name: Run cypress tests
     steps:
+      - run: echo "Targetted branch is ${{ inputs.branch }}"
       - name: Checkout code
         uses: actions/checkout@v2
 

--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -46,6 +46,39 @@ env:
   COMMENT_FAILURE_MSG: ':x: Cypress test run failed.'
 
 jobs:
+  test-add-comment:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number != '' }}
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ inputs.pr_number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: "${{ env.COMMENT_TAG }}"
+
+      - name: Add comment on the PR
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ inputs.pr_number }}
+          body: |
+            ### ${{ env.COMMENT_TAG }}
+
+            #### ${{ env.CYPRESS_VISBUILDER_ENABLED && env.COMMENT_SUCCESS_MSG || env.COMMENT_FAILURE_MSG }}
+
+            #### Inputs:
+            Test repo: `${{ env.REPO }}`
+            Test branch: `${{ env.TEST_BRANCH }}`
+            Spec: `${{ env.SPEC }}${{ env.ADDITIONAL_SPEC }}`
+
+            Link to results: 
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          edit-mode: replace
+
   cypress-tests:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -50,7 +50,6 @@ jobs:
       TERM: xterm
     name: Run cypress tests
     steps:
-      - name: Verify inputs
       - run: |
           echo "Repo: ${{ env.REPO }}"
           echo "Test branch: ${{ env.TEST_BRANCH }}"

--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -6,6 +6,14 @@ on:
     branches: [ '**' ]
     paths-ignore:
       - '**/*.md'
+  workflow_dispatch:
+    inputs: 
+      branch:
+        description: 'Execute tests from this branch'
+        required: true
+        default: '${{ github.base_ref }}'
+        type: string
+
 
 env:
   FTR_PATH: 'ftr'

--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -7,31 +7,30 @@ on:
     paths-ignore:
       - '**/*.md'
   workflow_dispatch:
-    inputs: 
-      repository:
-        description: 'Repo of the tests'
+    inputs:
+      test_repo:
+        description: 'Test repo'
         default: 'opensearch-project/opensearch-dashboards-functional-test'
         required: true
         type: string
-      branch:
-        description: 'Branch of the tests (default: target branch)'
-        default: ''
-        required: false
-        type: string
-      specs:
-        description: 'Additional tests to run'
-        default: ''
+      test_branch:
+        description: 'Test branch (default: source branch)'
         required: false
         type: string
       pr_number:
-        description: 'Pull request number to link results'
-        default: ''
+        description: 'PR Number'
         required: false
         type: number
+      specs:
+        description: 'Additional tests to run'
+        required: false
+        type: string
 
 env:
-  REPO: ${{ inputs.repository != '' && inputs.repository || 'opensearch-project/opensearch-dashboards-functional-test' }}
-  TEST_BRANCH: ${{ inputs.branch != '' && inputs.branch || github.base_ref }}
+  SOURCE_REPO: ${{ github.repository }}
+  SOURCE_BRANCH: ${{ github.base_ref }}
+  TEST_REPO: ${{ inputs.test_repo != '' && inputs.test_repo || 'opensearch-project/opensearch-dashboards-functional-test' }}
+  TEST_BRANCH: ${{ inputs.test_branch != '' && inputs.test_branch || github.base_ref }}
   FTR_PATH: 'ftr'
   START_CMD: 'node ../scripts/opensearch_dashboards --dev --no-base-path --no-watch'
   OPENSEARCH_SNAPSHOT_CMD: 'node ../scripts/opensearch snapshot'
@@ -52,6 +51,30 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: Get source information from PR number
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number != '' }}
+        id: get_pr_info
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: "${{ inputs.pr_number }}"
+            });
+
+            const sourceRepo = pr.head.repo.full_name;
+            const sourceBranch = pr.head.ref;
+            const sourceJSON = `{ 'source': { 'repo': '${sourceRepo}', 'branch': '${sourceBranch}' } }`;
+            return sourceJSON;
+
+      - name: Set source branch from PR number
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number != '' }}
+        run: |
+          echo "SOURCE_REPO=${{ fromJSON(steps.get_pr_info.outputs.result.source.repo) }}" >> $GITHUB_ENV
+          echo "SOURCE_BRANCH=${{ fromJSON(steps.get_pr_info.outputs.result.source.branch) }}" >> $GITHUB_ENV
+
       - name: Find Comment
         uses: peter-evans/find-comment@v2
         id: fc
@@ -71,7 +94,9 @@ jobs:
             #### ${{ env.CYPRESS_VISBUILDER_ENABLED && env.COMMENT_SUCCESS_MSG || env.COMMENT_FAILURE_MSG }}
 
             #### Inputs:
-            Test repo: `${{ env.REPO }}`
+            Source repo: `${{ env.SOURCE_REPO }}`
+            Source branch: `${{ env.SOURCE_BRANCH }}`
+            Test repo: `${{ env.TEST_REPO }}`
             Test branch: `${{ env.TEST_BRANCH }}`
             Spec: `${{ env.SPEC }}${{ env.ADDITIONAL_SPEC }}`
 
@@ -91,13 +116,42 @@ jobs:
       TERM: xterm
     name: Run cypress tests
     steps:
+      - name: Get source information from PR number
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number != '' }}
+        id: get_pr_info
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: "${{ inputs.pr_number }}"
+            });
+
+            const sourceRepo = pr.head.repo.full_name;
+            const sourceBranch = pr.head.ref;
+            const sourceJSON = `{ 'source': { 'repo': '${sourceRepo}', 'branch': '${sourceBranch}' } }`;
+            return sourceJSON;
+
+      - name: Set source branch from PR number
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number != '' }}
+        run: |
+          echo "SOURCE_REPO=${{ fromJSON(steps.get_pr_info.outputs.result.source.repo) }}" >> $GITHUB_ENV
+          echo "SOURCE_BRANCH=${{ fromJSON(steps.get_pr_info.outputs.result.source.branch) }}" >> $GITHUB_ENV
+
       - run: |
-          echo "Repo: ${{ env.REPO }}"
+          echo "Source repo: ${{ env.SOURCE_REPO }}"
+          echo "Source branch: ${{ env.SOURCE_BRANCH }}"
+          echo "Test repo: ${{ env.TEST_REPO }}"
           echo "Test branch: ${{ env.TEST_BRANCH }}"
           echo "Extra spec: ${{ env.ADDITIONAL_SPEC }}"
 
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          repository: ${{ env.SOURCE_REPO }}
+          ref: '${{ env.SOURCE_BRANCH }}'
 
       - name: Setup Node
         uses: actions/setup-node@v2
@@ -120,7 +174,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ${{ env.FTR_PATH }}
-          repository: ${{ env.REPO }}
+          repository: ${{ env.TEST_REPO }}
           ref: '${{ env.TEST_BRANCH }}'
 
       - name: Get Cypress version
@@ -195,9 +249,10 @@ jobs:
             #### ${{ needs.cypress-tests.result == 'success' && env.COMMENT_SUCCESS_MSG || env.COMMENT_FAILURE_MSG }}
 
             #### Inputs:
-            Test repo: `${{ env.REPO }}`
+            Source repo: `${{ env.SOURCE_REPO }}`
+            Source branch: `${{ env.SOURCE_BRANCH }}`
+            Test repo: `${{ env.TEST_REPO }}`
             Test branch: `${{ env.TEST_BRANCH }}`
-            Spec: `${{ env.SPEC }}${{ env.ADDITIONAL_SPEC }}`
 
             Link to results: 
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ trash
 target
 /build
 /bwc_tmp
+/scripts/random/data
+/scripts/random/stdout.txt
+/scripts/random/data.tar.gz
+/scripts/random.tar.gz
 .jruby
 .idea
 *.iml


### PR DESCRIPTION
### Description

Utilizing the GitHub `workflow_dispatch`, we can trigger a job with a specific input.

Here we are allowing for tests to be ran pulling down from: https://github.com/opensearch-project/opensearch-dashboards-functional-test

This workflow uses the target branch of the PR to pull down from the FTRepo and run the tests from that specific branch.

For example, PRs against `main` will pull down `main` from the FTRepo.

The problem occurs when new functionality is opened or a bug is fixed and, per industry standard, we want to see tests added to ensure functionality, stability, and raise the bar.

But the cypress tests PR into the FTRepo depends on the new code to be merged for the CI within the FTRepo to work. So we have a stalemate that usually slows down PR review time.

Here, a manual run can be triggered using the branch provided by the maintainer who ran the job.